### PR TITLE
Missing diff instruction at beginning of sequences

### DIFF
--- a/DiffLib.Specifications/DiffLib.Specifications.csproj
+++ b/DiffLib.Specifications/DiffLib.Specifications.csproj
@@ -57,6 +57,9 @@
       <Name>DiffLib</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/DiffLib.Specifications/PatienceSpecs.cs
+++ b/DiffLib.Specifications/PatienceSpecs.cs
@@ -43,7 +43,7 @@ namespace DiffLib.Specifications
         It should_give_an_equal_instruction_for_the_unchanged_code = () =>
             instructions[0].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Equal, new SubSequence(0, 0, 1, 1)));
         It should_give_an_add_instruction_for_the_new_line = () =>
-            instructions[1].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Inserted, new SubSequence(0, 1, 0, 1)));
+            instructions[1].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Inserted, new SubSequence(1, 1, 0, 1)));
     }
 
     [Subject(typeof(PatienceSequenceMatcher<>))]
@@ -98,5 +98,109 @@ namespace DiffLib.Specifications
             instructions[0].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Removed, new SubSequence(0, 0, 1, 0)));
         It should_give_an_add_instruction_for_the_new_code = () =>
             instructions[1].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Inserted, new SubSequence(0, 0, 0, 2)));
+    }
+
+    [Subject(typeof(Differencer<>))]
+    class when_diffing_a_file_that_adds_content_at_the_start : Patience
+    {
+        static string[] left;
+        static string[] right;
+        static DifferenceInstruction[] instructions;
+
+        Establish context = () =>
+        {
+            left = Lines(
+                "public  class MyException extends Exception {",
+                "",
+                "}"
+            );
+            right = Lines(
+                "/**",
+                " * Simple exception.",
+                " */",
+                "public  class MyException extends Exception {",
+                "",
+                "}"
+            );
+        };
+
+        Because of = () => instructions = Diff(left, right);
+
+        It should_have_two_instructions = () => instructions.Length.ShouldEqual(2);
+        It should_give_an_add_instruction_for_the_new_code = () =>
+            instructions[0].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Inserted, new SubSequence(0, 0, 0, 3)));
+        It should_give_an_equal_instruction_for_the_unchanged_code = () =>
+            instructions[1].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Equal, new SubSequence(0, 3, 3, 3)));
+    }
+
+    [Subject(typeof(Differencer<>))]
+    class when_diffing_a_file_that_removes_content_at_the_start : Patience
+    {
+        static string[] left;
+        static string[] right;
+        static DifferenceInstruction[] instructions;
+
+        Establish context = () =>
+        {
+            left = Lines(
+                "/**",
+                " * Simple exception.",
+                " */",
+                "public  class MyException extends Exception {",
+                "",
+                "}"
+            );
+            right = Lines(
+                "public  class MyException extends Exception {",
+                "",
+                "}"
+            );
+        };
+
+        Because of = () => instructions = Diff(left, right);
+
+        It should_have_two_instructions = () => instructions.Length.ShouldEqual(2);
+        It should_give_a_remove_instruction_for_the_old_code = () =>
+            instructions[0].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Removed, new SubSequence(0, 0, 3, 0)));
+        It should_give_an_equal_instruction_for_the_unchanged_code = () =>
+            instructions[1].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Equal, new SubSequence(3, 0, 3, 3)));
+    }
+
+    [Subject(typeof(Differencer<>))]
+    class when_diffing_a_file_that_removes_content_at_the_start_and_adds_to_the_end : Patience
+    {
+        static string[] left;
+        static string[] right;
+        static DifferenceInstruction[] instructions;
+
+        Establish context = () =>
+        {
+            left = Lines(
+                "/**",
+                " * Simple exception.",
+                " */",
+                "public  class MyException extends Exception {",
+                "",
+                "}"
+            );
+            right = Lines(
+                "public  class MyException extends Exception {",
+                "",
+                "}",
+                "/**",
+                " * Removed some comment.",
+                " */"
+            );
+        };
+
+        Because of = () => instructions = Diff(left, right);
+
+        It should_have_two_instructions = () => instructions.Length.ShouldEqual(3);
+        It should_give_a_remove_instruction_for_the_old_code = () =>
+            instructions[0].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Removed, new SubSequence(0, 0, 3, 0)));
+        It should_give_an_equal_instruction_for_the_unchanged_code = () =>
+            instructions[1].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Equal, new SubSequence(3, 0, 3, 3)));
+        It should_give_an_add_instruction_for_the_new_code = () =>
+            instructions[2].ShouldEqual(new DifferenceInstruction(DifferenceOperation.Inserted, new SubSequence(6, 3, 0, 3)));
     }
 }

--- a/DiffLib/Differencer.cs
+++ b/DiffLib/Differencer.cs
@@ -67,6 +67,11 @@ namespace DiffLib
                         yield return new DifferenceInstruction(DifferenceOperation.Removed,
                             new SubSequence(lastLeftIndex, 0, diff, 0));
                 }
+                else if (item.LeftIndex > 0 && item.RightIndex == 0)
+                {
+                    yield return new DifferenceInstruction(DifferenceOperation.Removed,
+                        new SubSequence(0, 0, item.LeftLength, 0));
+                }
 
                 if (lastRightIndex != -1)
                 {
@@ -74,6 +79,11 @@ namespace DiffLib
                     if (diff > 0)
                         yield return new DifferenceInstruction(DifferenceOperation.Inserted,
                             new SubSequence(0, lastRightIndex, 0, diff));
+                }
+                else if (item.RightIndex > 0 && item.LeftIndex == 0)
+                {
+                    yield return new DifferenceInstruction(DifferenceOperation.Inserted,
+                        new SubSequence(0, 0, 0, item.RightIndex));
                 }
 
                 if (item.LeftLength > 0 && item.LeftLength == item.RightLength)
@@ -95,8 +105,9 @@ namespace DiffLib
             if (lastRightIndex < right.Count)
             {
                 if (lastRightIndex < 0) lastRightIndex = 0;
+                if (lastLeftIndex < 0) lastLeftIndex = 0;
                 yield return new DifferenceInstruction(DifferenceOperation.Inserted,
-                            new SubSequence(0, lastRightIndex, 0, right.Count - lastRightIndex));
+                            new SubSequence(lastLeftIndex, lastRightIndex, 0, right.Count - lastRightIndex));
             }
         }
 


### PR DESCRIPTION
- Correcting unit tests.
- Adding missing diff sequences at the start of differences.

Closes #2.
